### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -11,6 +11,8 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: ./backend

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,6 +14,8 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: ./frontend


### PR DESCRIPTION
Potential fix for [https://github.com/GermanCoding/WallboxUI/security/code-scanning/2](https://github.com/GermanCoding/WallboxUI/security/code-scanning/2)

In general, the fix is to explicitly restrict the `GITHUB_TOKEN` permissions for the `build` job to the minimum required, which here is read access to the repository contents. This is done by adding a `permissions:` block either at the workflow root (affecting all jobs that don’t override it) or directly under the `build` job.

To avoid changing existing behavior and to keep job-specific control (since `docker-backend-arch` already has its own `permissions:`), the best targeted fix is to add a `permissions:` section under the `build` job, alongside `runs-on` and `defaults`. We’ll set `contents: read`, which is sufficient for `actions/checkout` and doesn’t grant any write scopes. Concretely, in `.github/workflows/django.yml` we will insert:

```yaml
    runs-on: ubuntu-latest
    permissions:
      contents: read
    defaults:
      run:
        working-directory: ./backend
```

No additional imports, methods, or definitions are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
